### PR TITLE
Add reading/writing from scanline-oriented images, and reading for tiled images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/kazeharu*
+/output*

--- a/openimageio-sys/src/glue/helpers.cpp
+++ b/openimageio-sys/src/glue/helpers.cpp
@@ -15,15 +15,15 @@ void freeCString(const char *ptr) {
     delete[] ptr;
 }
 
-static char** makeCharArray(int size) {
+char** makeCharArray(int size) {
     return (char**)calloc(sizeof(char*), size);
 }
 
-static void setArrayString(char **a, char *s, int n) {
+void setArrayString(char **a, char *s, int n) {
     a[n] = s;
 }
 
-static void freeCharArray(char **a, int size) {
+void freeCharArray(char **a, int size) {
     int i;
     for (i = 0; i < size; i++)
         free(a[i]);

--- a/openimageio-sys/src/glue/imageinput.cpp
+++ b/openimageio-sys/src/glue/imageinput.cpp
@@ -119,12 +119,13 @@ bool OIIO_ImageInput_read_image_format2(
             cbk_data);
 }
 
-bool OIIO_ImageInput_read_scanline_floats(OIIO_ImageInput *in, int y, int z, float *data) {
-    return OIIO_CAST(ImageInput ,in)->read_scanline(y, z, data);
+bool OIIO_ImageInput_read_scanline_format(OIIO_ImageInput *in, int y, int z, OIIO_TypeDesc format, void* data, stride_t xstride) {
+    return OIIO_CAST(ImageInput ,in)->read_scanline(y, z, unwrapTypeDesc(format), data, xstride);
 }
 
-bool OIIO_ImageInput_read_tile_floats(OIIO_ImageInput *in, int x, int y, int z, float *data) {
-    return OIIO_CAST(ImageInput ,in)->read_tile(x, y, z, data);
+bool OIIO_ImageInput_read_tile_format(OIIO_ImageInput *in, int x, int y, int z, OIIO_TypeDesc format, void* data,
+ 									stride_t xstride, stride_t ystride, stride_t zstride) {
+    return OIIO_CAST(ImageInput ,in)->read_tile(x, y, z, unwrapTypeDesc(format), data, xstride, ystride, zstride);
 }
 
 

--- a/openimageio-sys/src/glue/imageoutput.cpp
+++ b/openimageio-sys/src/glue/imageoutput.cpp
@@ -32,6 +32,10 @@ bool OIIO_ImageOutput_write_image(OIIO_ImageOutput *out,
                                                     zstride);
 }
 
+bool OIIO_ImageOutput_write_scanline(OIIO_ImageOutput *out, int y, int z, OIIO_TypeDesc format, const void *data, stride_t xstride) {
+    return OIIO_CAST(ImageOutput, out)->write_scanline(y, z, unwrapTypeDesc(format), data, xstride);
+}
+
 bool
 OIIO_ImageOutput_open2(OIIO_ImageOutput *out, OIIO_StringRef name, int subimages, const OIIO_ImageSpec *const *specs) {
     std::string s_filename{name.ptr, name.len};

--- a/openimageio-sys/src/glue/oiio.h
+++ b/openimageio-sys/src/glue/oiio.h
@@ -150,6 +150,8 @@ bool OIIO_ImageOutput_write_image(OIIO_ImageOutput *out,
                                   ptrdiff_t xstride,
                                   ptrdiff_t ystride,
                                   ptrdiff_t zstride);
+bool OIIO_ImageOutput_write_scanline(OIIO_ImageOutput *out, int y, int z, OIIO_TypeDesc format, const void *data, stride_t xstride);
+
 
 //---------------------------------------------------------------------
 // OIIO_ImageSpec

--- a/openimageio-sys/src/glue/oiio.h
+++ b/openimageio-sys/src/glue/oiio.h
@@ -101,11 +101,11 @@ int OIIO_ImageInput_current_subimage(const OIIO_ImageInput *in);
 int OIIO_ImageInput_current_miplevel(const OIIO_ImageInput *in);
 bool OIIO_ImageInput_seek_subimage(OIIO_ImageInput *in, int subimage, OIIO_ImageSpec *newspec);
 bool OIIO_ImageInput_seek_subimage_miplevel(OIIO_ImageInput *in, int subimage, int miplevel, OIIO_ImageSpec *newspec);
-bool OIIO_ImageInput_read_scanline_floats(OIIO_ImageInput *in, int y, int z, float *data);
-// bool OIIO_ImageInput_read_scanline_format(OIIO_ImageInput *in, int y, int z, OIIO_TypeDesc format, void* data, stride_t xstride);
-bool OIIO_ImageInput_read_tile_floats(OIIO_ImageInput *in, int x, int y, int z, float *data);
-// bool OIIO_ImageInput_read_tile_format(OIIO_ImageInput *in, int x, int y, int z, OIIO_TypeDesc format, void* data,
-// 									stride_t xstride, stride_t ystride, stride_t zstride);
+// bool OIIO_ImageInput_read_scanline_floats(OIIO_ImageInput *in, int y, int z, float *data);
+bool OIIO_ImageInput_read_scanline_format(OIIO_ImageInput *in, int y, int z, OIIO_TypeDesc format, void* data, stride_t xstride);
+// bool OIIO_ImageInput_read_tile_floats(OIIO_ImageInput *in, int x, int y, int z, float *data);
+bool OIIO_ImageInput_read_tile_format(OIIO_ImageInput *in, int x, int y, int z, OIIO_TypeDesc format, void* data,
+ 									stride_t xstride, stride_t ystride, stride_t zstride);
 bool OIIO_ImageInput_read_image_floats(OIIO_ImageInput *in, float *data);
 bool OIIO_ImageInput_read_image_format(OIIO_ImageInput *in, OIIO_TypeDesc format, void *data, void *cbk_data);
 bool OIIO_ImageInput_read_image_format2(OIIO_ImageInput *in,

--- a/src/error.rs
+++ b/src/error.rs
@@ -14,6 +14,7 @@ pub enum Error {
     NoncontiguousChannels,
     InvalidParameter,
     BufferTooSmall,
+    InvalidForImageType,
 }
 
 impl error::Error for Error {}
@@ -37,6 +38,7 @@ impl fmt::Display for Error {
             }
             Error::InvalidChannelIndex => write!(f, "non-existent channel index"),
             Error::BufferTooSmall => write!(f, "buffer was too small"),
+            Error::InvalidForImageType=> write!(f, "image type did not support operation"),
             //_ => write!(f, "Unknown error."),
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -122,6 +122,26 @@ mod tests {
     }
 
     #[test]
+    fn read_image_scanline() {
+        // scanline based png
+        let mut img = ImageInput::open("test_images/kazeharu.png").unwrap();
+        assert!(img.spec().tile_width() == 0);
+
+        let mut img_data: Vec<u8> = Vec::new();
+        img_data.resize(img.spec().width() as usize * img.spec().num_channels(), 0);
+
+        // reading all scanlines should be the same as reading the whole image
+        let mut all_scanlines: Vec<u8> = Vec::new();
+        for y in 0..img.spec().height() {
+            img.read_scanline(y as i32, 0, &mut img_data).unwrap();
+            all_scanlines.extend(img_data.clone().iter());
+        }
+
+        let whole_img: ImageBuffer<u8> = img.read().unwrap();
+        assert_eq!(all_scanlines, whole_img.data);
+    }
+
+    #[test]
     fn open_image_exr() {
         let mut img = ImageInput::open("test_images/output0013.exr").unwrap();
         for c in img.spec().channels() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -142,6 +142,62 @@ mod tests {
     }
 
     #[test]
+    fn write_image_scanline() {
+        // scanline based png
+        let mut img = ImageInput::open("test_images/kazeharu.png").unwrap();
+        let data: ImageBuffer<u8> = img.read().unwrap();
+
+        let mut out = ImageOutput::create("kazeharu.png").unwrap();
+        let mut out = out.open(&img.spec()).unwrap();
+        out.write_image(data.data()).unwrap();
+
+        let mut out2 = ImageOutput::create("kazeharu_scanline.png").unwrap();
+        let mut out2 = out2.open(&img.spec()).unwrap();
+        let row_width: usize = data.width * data.num_channels;
+        for y in 0..data.height() as usize {
+            out2.write_scanline(y as i32, 0, &data.data[(y * row_width)..((y + 1) * row_width)]).unwrap();
+        }
+
+        // Written image should be identical
+        fn file_contents(f: &str) -> Vec<u8> {
+            use std::io::Read;
+            use std::fs::File;
+            let mut file = File::open(f).unwrap();
+            let mut res = Vec::new();
+            file.read_to_end(&mut res).unwrap();
+            res
+        }
+
+        assert_eq!(file_contents("kazeharu.png"), file_contents("kazeharu_scanline.png"));
+    }
+
+    #[test]
+    fn read_tiled() {
+        let mut img = ImageInput::open("test_images/tiled.tif").unwrap();
+        assert!(img.spec().tile_width() > 0);
+        // read first tile, verify it matches the same data of the whole image read with 'read()'
+        let mut tiled_data: Vec<u8> = Vec::new();
+        tiled_data.resize(img.spec().tile_width() * img.spec().tile_height() * img.spec().num_channels(), 0);
+        img.read_tile(0, 0, 0, &mut tiled_data).unwrap();
+
+        let mut whole_img: ImageBuffer<u8> = img.read().unwrap();
+
+        assert!(whole_img.data().len() > tiled_data.len());
+        // Manually split out the specific tile we read from the whole image 
+        let tile_from_whole_img: Vec<u8> = 
+            whole_img.data
+            .chunks_mut(img.spec().width() as usize * img.spec().num_channels()) // image rows
+            .map(|chunk| {
+                chunk[0..(img.spec().tile_width() * img.spec().num_channels())].to_vec() // chop down to tile width
+            })
+            .take(img.spec().tile_height()) // chop down to tile height
+            .flatten() // re-merge chunks
+            .collect();
+
+        assert_eq!(tile_from_whole_img, tiled_data);
+    }
+
+    #[test]
     fn open_image_exr() {
         let mut img = ImageInput::open("test_images/output0013.exr").unwrap();
         for c in img.spec().channels() {

--- a/src/output.rs
+++ b/src/output.rs
@@ -118,6 +118,28 @@ impl<'a> SingleImageOutput<'a> {
         }
     }
 
+    pub fn write_scanline<T: ImageData>(&mut self, y: i32, z: i32, pixels: &[T]) -> Result<(), Error> {
+        let spec = self.spec();
+        let nch = spec.num_channels();
+        let _n = (spec.width() * spec.height() * spec.depth()) as usize * nch;
+
+        let write_result = unsafe {
+            sys::OIIO_ImageOutput_write_scanline(
+                self.0.ptr,
+                y,
+                z,
+                T::DESC.0,
+                pixels.as_ptr() as *const c_void,
+                sys::OIIO_AutoStride,
+            )
+        };
+        if !write_result {
+            Err(Error::WriteError(self.0.get_last_error()))
+        } else {
+            Ok(())
+        }
+    }
+
     // finish writing to this subimage (and release the borrow)
     pub fn close(self) {}
 }

--- a/src/spec.rs
+++ b/src/spec.rs
@@ -192,6 +192,18 @@ impl ImageSpec {
         )
     }
 
+    pub fn tile_width(&self) -> usize {
+        unsafe { sys::OIIO_ImageSpec_tile_width(&self.0) as usize }
+    }
+
+    pub fn tile_height(&self) -> usize {
+        unsafe { sys::OIIO_ImageSpec_tile_height(&self.0) as usize }
+    }
+
+    pub fn tile_depth(&self) -> usize {
+        unsafe { sys::OIIO_ImageSpec_tile_depth(&self.0) as usize }
+    }
+
     /// (OpenImageIO:) The number of channels (color values) present in each pixel of the image.
     ///
     /// For example, an RGB image has 3 channels.
@@ -438,4 +450,3 @@ impl Deref for ImageSpecOwned {
         unsafe { &*(self.0 as *const ImageSpec) }
     }
 }
-


### PR DESCRIPTION
There were also a couple compilation errors for me (linux, rust 1.39.0) that I had to fix.

I wrote tests and it seems to work as I'd expect!